### PR TITLE
Add Giphy command

### DIFF
--- a/src/Chat/Plugin/Giphy.php
+++ b/src/Chat/Plugin/Giphy.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Room11\Jeeves\Chat\Plugin;
+
+use Room11\Jeeves\Chat\Client\ChatClient;
+use Room11\Jeeves\Chat\Command\Command;
+use Room11\Jeeves\Chat\Command\Message;
+
+class Giphy implements Plugin
+{
+    const COMMAND = 'giphy';
+    const PUBLIC_BETA_API_KEY = 'dc6zaTOxFJmzC';
+
+    const RATING_Y = 'y';
+    const RATING_G = 'g';
+    const RATING_PG = 'pg';
+    const RATING_PG13 = 'pg-13';
+    const RATING_R = 'r';
+
+    const VALID_RATINGS = [
+        self::RATING_Y,
+        self::RATING_G,
+        self::RATING_PG,
+        self::RATING_PG13,
+        self::RATING_R
+    ];
+
+    private $chatClient;
+    private $apiKey;
+    private $rating;
+
+    public function __construct(
+        ChatClient $chatClient,
+        $apiKey = self::PUBLIC_BETA_API_KEY,
+        $rating = self::RATING_PG13
+    ) {
+        $this->chatClient = $chatClient;
+        $this->apiKey = $apiKey;
+        $this->setRating($rating);
+    }
+
+    private function setRating($rating): void
+    {
+        if (!in_array($rating, self::VALID_RATINGS)) {
+            throw new \DomainException(
+                sprintf(
+                    'Rating must be one of %s. Got %s',
+                    implode(', ', self::VALID_RATINGS),
+                    $rating
+                )
+            );
+        }
+
+        $this->rating = $rating;
+    }
+
+    public function handle(Message $message): \Generator
+    {
+        if (!$this->validMessage($message)) {
+            return;
+        }
+
+        yield from $this->getResult($message);
+    }
+
+    private function validMessage(Message $message): bool
+    {
+        return $message instanceof Command
+            && $message->getCommand() === self::COMMAND
+            && $message->getParameters();
+    }
+
+    private function getResult(Message $message): \Generator
+    {
+        $response = yield from $this->chatClient->request(
+            'http://api.giphy.com/v1/gifs/random?' . http_build_query([
+                'api_key' => $this->apiKey,
+                'rating' => $this->rating,
+                'tag' => implode('%20', $message->getParameters())
+            ])
+        );
+
+        $result = json_decode($response->getBody(), true);
+
+        yield from $this->chatClient->postMessage($this->getMessage($result));
+    }
+
+    private function getMessage(array $result): string
+    {
+        return empty($result['data'])
+            ? 'Very iffy! Jeeves found no giphy :('
+            : $result['data']['image_url'];
+    }
+}

--- a/src/Chat/Plugin/Giphy.php
+++ b/src/Chat/Plugin/Giphy.php
@@ -2,13 +2,19 @@
 
 namespace Room11\Jeeves\Chat\Plugin;
 
+use Amp\Artax\HttpClient;
+use Amp\Artax\Response as HttpResponse;
 use Room11\Jeeves\Chat\Client\ChatClient;
-use Room11\Jeeves\Chat\Command\Command;
-use Room11\Jeeves\Chat\Command\Message;
+use Room11\Jeeves\Chat\Message\Command;
+use Room11\Jeeves\Chat\Plugin;
+use Room11\Jeeves\Chat\Plugin\Traits\CommandOnly;
+use Room11\Jeeves\Chat\PluginCommandEndpoint;
 
 class Giphy implements Plugin
 {
-    const COMMAND = 'giphy';
+    use CommandOnly;
+
+    const API_BASE_URL = 'http://api.giphy.com/';
     const PUBLIC_BETA_API_KEY = 'dc6zaTOxFJmzC';
 
     const RATING_Y = 'y';
@@ -26,20 +32,23 @@ class Giphy implements Plugin
     ];
 
     private $chatClient;
+    private $httpClient;
     private $apiKey;
     private $rating;
 
     public function __construct(
         ChatClient $chatClient,
+        HttpClient $httpClient,
         $apiKey = self::PUBLIC_BETA_API_KEY,
         $rating = self::RATING_PG13
     ) {
         $this->chatClient = $chatClient;
+        $this->httpClient = $httpClient;
         $this->apiKey = $apiKey;
         $this->setRating($rating);
     }
 
-    private function setRating($rating): void
+    private function setRating($rating) /*: void*/
     {
         if (!in_array($rating, self::VALID_RATINGS)) {
             throw new \DomainException(
@@ -54,41 +63,53 @@ class Giphy implements Plugin
         $this->rating = $rating;
     }
 
-    public function handle(Message $message): \Generator
-    {
-        if (!$this->validMessage($message)) {
-            return;
-        }
-
-        yield from $this->getResult($message);
-    }
-
-    private function validMessage(Message $message): bool
-    {
-        return $message instanceof Command
-            && $message->getCommand() === self::COMMAND
-            && $message->getParameters();
-    }
-
-    private function getResult(Message $message): \Generator
-    {
-        $response = yield from $this->chatClient->request(
-            'http://api.giphy.com/v1/gifs/random?' . http_build_query([
-                'api_key' => $this->apiKey,
-                'rating' => $this->rating,
-                'tag' => implode('%20', $message->getParameters())
-            ])
-        );
-
-        $result = json_decode($response->getBody(), true);
-
-        yield from $this->chatClient->postMessage($this->getMessage($result));
-    }
-
     private function getMessage(array $result): string
     {
         return empty($result['data'])
             ? 'Very iffy! Jeeves found no giphy :('
             : $result['data']['image_url'];
+    }
+
+    public function random(Command $command): \Generator
+    {
+        if (!$command->hasParameters()) {
+            return;
+        }
+
+        /** @var HttpResponse $response */
+        $response = yield $this->httpClient->request(
+            self::API_BASE_URL . 'v1/gifs/random?' . http_build_query([
+                'api_key' => $this->apiKey,
+                'rating' => $this->rating,
+                'tag' => implode(' ', $command->getParameters())
+            ])
+        );
+
+        $result = json_decode($response->getBody(), true);
+
+        yield from $this->chatClient->postMessage($command->getRoom(), $this->getMessage($result));
+    }
+
+    public function getName(): string
+    {
+        return 'Giphy';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Gets random gifs from Giphy and displays them in oneboxes';
+    }
+
+    public function getHelpText(array $args): string
+    {
+        // TODO: Implement getHelpText() method.
+    }
+
+    /**
+     * @return PluginCommandEndpoint[]
+     */
+    public function getCommandEndpoints(): array
+    {
+        return [new PluginCommandEndpoint('Random', [$this, 'random'], 'giphy')];
     }
 }


### PR DESCRIPTION
Connects Jeeves to https://github.com/Giphy/GiphyAPI (/random endpoint)

Example call

    !!giphy Chuck Norris

should post the image url of a random gif of Chuck Norris to the chat.

By default images are limited to PG-13 as per the ToS of Stack Exchange.
The plugin uses the default Public Beta key of Giphy, which is rate
limited. A dedicated API key (and rating) can be ctor injected.