### PR TITLE
Refactoring/plugin interface

### DIFF
--- a/src/Chat/Client/ChatClient.php
+++ b/src/Chat/Client/ChatClient.php
@@ -8,6 +8,7 @@ use Amp\Artax\Request;
 use Amp\Pause;
 use Room11\Jeeves\Chat\Room\Room;
 use Room11\Jeeves\Fkey\FKey;
+use Room11\Jeeves\Chat\Message\Message as ChatMessage;
 
 class ChatClient {
     private $httpClient;
@@ -111,6 +112,11 @@ class ChatClient {
 
             yield from $this->postMessage("@PeeHaa error has been logged. Fix it fix it fix it fix it.");
         }
+    }
+
+    public function postReply(ChatMessage $origin, string $text): \Generator
+    {
+        yield from $this->postMessage(":{$origin->getId()} {$text}");
     }
 
     public function editMessage(int $id, string $text): \Generator {

--- a/src/Chat/Plugin/CodeFormat.php
+++ b/src/Chat/Plugin/CodeFormat.php
@@ -8,13 +8,15 @@ use Room11\Jeeves\Chat\Command\Void;
 use Room11\Jeeves\Chat\Message\NewMessage;
 
 class CodeFormat implements Plugin {
+    use MessageOnlyPlugin;
+
     private $chatClient;
 
     public function __construct(ChatClient $chatClient) {
         $this->chatClient = $chatClient;
     }
 
-    public function handle(Message $message): \Generator {
+    public function handleMessage(Message $message): \Generator {
         if (!$this->validMessage($message)) {
             return;
         }

--- a/src/Chat/Plugin/CommandOnlyPlugin.php
+++ b/src/Chat/Plugin/CommandOnlyPlugin.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Room11\Jeeves\Chat\Plugin;
+
+use Room11\Jeeves\Chat\Command\Message;
+
+/**
+ * Provides default interface method implementations for plugins which only handle commands
+ */
+trait CommandOnlyPlugin
+{
+    public function handleMessage(Message $message): \Generator { yield; }
+
+    public function handlesAllMessages(): bool { return false; }
+}

--- a/src/Chat/Plugin/Lick.php
+++ b/src/Chat/Plugin/Lick.php
@@ -4,11 +4,10 @@ namespace Room11\Jeeves\Chat\Plugin;
 
 use Room11\Jeeves\Chat\Client\ChatClient;
 use Room11\Jeeves\Chat\Command\Command;
-use Room11\Jeeves\Chat\Command\Message;
 
 class Lick implements Plugin
 {
-    const COMMAND = "lick";
+    use CommandOnlyPlugin;
 
     const RESPONSES = [
         "Eeeeeeew",
@@ -22,27 +21,33 @@ class Lick implements Plugin
         $this->chatClient = $chatClient;
     }
 
-    public function handle(Message $message): \Generator {
-        if (!$this->validMessage($message)) {
-            return;
-        }
-
-        yield from $this->getResult($message);
-    }
-
-    private function validMessage(Message $message): bool {
-        return $message instanceof Command
-            && $message->getCommand() === self::COMMAND;
-    }
-
-    private function getResult(Message $message): \Generator {
-        $reply = $message->getOrigin();
-
-        yield from $this->chatClient->postMessage(":$reply " . $this->getRandomReply());
+    private function getResult(Command $command): \Generator {
+        yield from $this->chatClient->postReply($command->getMessage(), $this->getRandomReply());
     }
 
     private function getRandomReply(): string
     {
         return self::RESPONSES[random_int(0, (count(self::RESPONSES) - 1))];
+    }
+
+    /**
+     * Handle a command message
+     *
+     * @param Command $command
+     * @return \Generator
+     */
+    public function handleCommand(Command $command): \Generator
+    {
+        yield from $this->getResult($command);
+    }
+
+    /**
+     * Get a list of specific commands handled by this plugin
+     *
+     * @return string[]
+     */
+    public function getHandledCommands(): array
+    {
+        return ['lick'];
     }
 }

--- a/src/Chat/Plugin/MessageOnlyPlugin.php
+++ b/src/Chat/Plugin/MessageOnlyPlugin.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Room11\Jeeves\Chat\Plugin;
+
+use Room11\Jeeves\Chat\Command\Command;
+
+trait MessageOnlyPlugin
+{
+    public function handleCommand(Command $command): \Generator { yield; }
+
+    public function getHandledCommands(): array { return []; }
+
+    public function handlesAllMessages(): bool { return true; }
+}

--- a/src/Chat/Plugin/Plugin.php
+++ b/src/Chat/Plugin/Plugin.php
@@ -3,8 +3,37 @@
 namespace Room11\Jeeves\Chat\Plugin;
 
 use Room11\Jeeves\Chat\Command\Message;
+use Room11\Jeeves\Chat\Command\Command;
 
 interface Plugin
 {
-    public function handle(Message $message): \Generator;
+    /**
+     * Handle a general message
+     *
+     * @param Message $message
+     * @return \Generator
+     */
+    public function handleMessage(Message $message): \Generator;
+
+    /**
+     * Handle a command message
+     *
+     * @param Command $command
+     * @return \Generator
+     */
+    public function handleCommand(Command $command): \Generator;
+
+    /**
+     * Get a list of specific commands handled by this plugin
+     *
+     * @return string[]
+     */
+    public function getHandledCommands(): array;
+
+    /**
+     * Returns true if the plugin handles all messages, false if it only handles specific commands
+     *
+     * @return bool
+     */
+    public function handlesAllMessages(): bool;
 }

--- a/src/Chat/Plugin/RFC.php
+++ b/src/Chat/Plugin/RFC.php
@@ -5,10 +5,10 @@ namespace Room11\Jeeves\Chat\Plugin;
 use Amp\Artax\Response;
 use Room11\Jeeves\Chat\Client\ChatClient;
 use Room11\Jeeves\Chat\Command\Command;
-use Room11\Jeeves\Chat\Command\Message;
 
-class RFC implements Plugin {
-    const COMMAND = "rfcs";
+class RFC implements Plugin
+{
+    use CommandOnlyPlugin;
 
     private $chatClient;
 
@@ -16,20 +16,7 @@ class RFC implements Plugin {
         $this->chatClient = $chatClient;
     }
 
-    public function handle(Message $message): \Generator {
-        if (!$this->validMessage($message)) {
-            return;
-        }
-
-        yield from $this->getResult($message);
-    }
-
-    private function validMessage(Message $message): bool {
-        return $message instanceof Command
-        && $message->getCommand() === self::COMMAND;
-    }
-
-    private function getResult(Message $message): \Generator {
+    private function getResult(): \Generator {
         $uri = "https://wiki.php.net/rfc";
 
         /** @var Response $response */
@@ -56,6 +43,7 @@ class RFC implements Plugin {
                 continue;
             }
 
+            /** @var \DOMElement $node */
             /** @var \DOMElement $href */
             $href = $node->getElementsByTagName("a")->item(0);
 
@@ -76,5 +64,26 @@ class RFC implements Plugin {
             "[tag:rfc-vote] %s",
             implode(" | ", $rfcsInVoting)
         ));
+    }
+
+    /**
+     * Handle a command message
+     *
+     * @param Command $command
+     * @return \Generator
+     */
+    public function handleCommand(Command $command): \Generator
+    {
+        yield from $this->getResult();
+    }
+
+    /**
+     * Get a list of specific commands handled by this plugin
+     *
+     * @return string[]
+     */
+    public function getHandledCommands(): array
+    {
+        return ['rfcs'];
     }
 }

--- a/src/Chat/Plugin/Rebecca.php
+++ b/src/Chat/Plugin/Rebecca.php
@@ -8,7 +8,7 @@ use Room11\Jeeves\Chat\Command\Message;
 
 class Rebecca implements Plugin
 {
-    const COMMAND = 'rebecca';
+    use CommandOnlyPlugin;
 
     const VIDEO_URL = 'https://www.youtube.com/watch?v=kfVsfOSbJY0';
 
@@ -18,27 +18,8 @@ class Rebecca implements Plugin
         $this->chatClient = $chatClient;
     }
 
-    public function handle(Message $message): \Generator {
-        if (!$this->validMessage($message)) {
-            return;
-        }
-
-        yield from $this->getResult($message);
-    }
-
-    private function validMessage(Message $message): bool {
-        return $message instanceof Command
-            && $message->getCommand() === self::COMMAND;
-    }
-
-    private function getResult(Message $message): \Generator {
-        yield from $this->chatClient->postMessage(
-            sprintf(
-                ':%s %s',
-                $message->getOrigin(),
-                $this->getRebeccaLinkIfFriday()
-            )
-        );
+    private function getResult(Command $command): \Generator {
+        yield from $this->chatClient->postReply($command->getMessage(), $this->getRebeccaLinkIfFriday());
     }
 
     private function getRebeccaLinkIfFriday(): string
@@ -74,5 +55,26 @@ class Rebecca implements Plugin
         $friday = new \DateTime('next friday', new \DateTimeZone('UTC'));
 
         return $now->diff($friday);
+    }
+
+    /**
+     * Handle a command message
+     *
+     * @param Command $command
+     * @return \Generator
+     */
+    public function handleCommand(Command $command): \Generator
+    {
+        yield from $this->getResult($command);
+    }
+
+    /**
+     * Get a list of specific commands handled by this plugin
+     *
+     * @return string[]
+     */
+    public function getHandledCommands(): array
+    {
+        return ['rebecca'];
     }
 }

--- a/src/Chat/Plugin/Version.php
+++ b/src/Chat/Plugin/Version.php
@@ -4,33 +4,17 @@ namespace Room11\Jeeves\Chat\Plugin;
 
 use Room11\Jeeves\Chat\Client\ChatClient;
 use Room11\Jeeves\Chat\Command\Command;
-use Room11\Jeeves\Chat\Command\Message;
 use SebastianBergmann\Version as SebastianVersion;
 
 class Version implements Plugin
 {
-    const COMMAND = 'version';
+    use CommandOnlyPlugin;
 
     private $chatClient;
 
     public function __construct(ChatClient $chatClient)
     {
         $this->chatClient = $chatClient;
-    }
-
-    public function handle(Message $message): \Generator
-    {
-        if (!$this->validMessage($message)) {
-            return;
-        }
-
-        yield from $this->getVersion();
-    }
-
-    private function validMessage(Message $message): bool
-    {
-        return $message instanceof Command
-        && $message->getCommand() === self::COMMAND;
     }
 
     private function getVersion(): \Generator
@@ -55,5 +39,26 @@ class Version implements Plugin
         }, $version);
 
         yield from $this->chatClient->postMessage($version);
+    }
+
+    /**
+     * Handle a command message
+     *
+     * @param Command $command
+     * @return \Generator
+     */
+    public function handleCommand(Command $command): \Generator
+    {
+        yield from $this->getVersion();
+    }
+
+    /**
+     * Get a list of specific commands handled by this plugin
+     *
+     * @return string[]
+     */
+    public function getHandledCommands(): array
+    {
+        return ['version'];
     }
 }

--- a/tests/src/Chat/Plugin/RebeccaTest.php
+++ b/tests/src/Chat/Plugin/RebeccaTest.php
@@ -18,6 +18,6 @@ class RebeccaTest extends AbstractPluginTest
 
     public function testCommandName()
     {
-        $this->assertSame('rebecca', Rebecca::COMMAND);
+        $this->assertSame(['rebecca'], $this->plugin->getHandledCommands());
     }
 }


### PR DESCRIPTION
This is a sizable change including a fairly hefty BC break, but I think it's worthwhile.

It changes the plugin interface so that the plugin specifies at load time which commands it will handle and whether it is interested in non-command messages. This means that message processing is a lot more efficient as it only sends the message to plugins that might be interested in it.

As an aside, it fixes a whole bunch of static analysis issues without any more docblocks :-)