### PR TITLE
Only prods a user about W3S if it's a new message event.

### DIFF
--- a/src/Plugins/AntiW3Schools.php
+++ b/src/Plugins/AntiW3Schools.php
@@ -62,9 +62,18 @@ class AntiW3Schools extends BasePlugin
      */
     public function handleMessage(Message $message): Promise
     {
-        return $this->containsTerribleUri($message->getText())
+        return $this->isSuitable($message) && $this->containsTerribleUri($message->getText())
             ? $this->chatClient->postReply($message, $this->createReply($message))
             : new Success();
+    }
+
+    /**
+     * Check whether a message is initially suitable for a response from this plugin.
+     * @param Message $message
+     * @return bool
+     */
+    private function isSuitable(Message $message) {
+        return $message->getType() === Message::TYPE_NEW;
     }
 
     /**


### PR DESCRIPTION
 For now, this is to prevent potentially spamming if a user edits an existing post.
Testing showed that if I submitted a message containing a W3S link and edited it, Jeeves would try to send a new message, which is caught and bounced back by SO chat.
The commit aims to stop that from happening by just locking out this plugin from triggering on edits and deletes.

Here's the log which prompted this:

```
[2016-10-11 21:52:04] 1 events targeting chat.stackoverflow.com#100286 to process
[2016-10-11 21:52:04] Processing room event #67973297
object(Room11\Jeeves\Chat\Event\EditMessage)#533 (10) {
  ["event_type"]=>
  int(2)
  ["time_stamp"]=>
  int(1476222712)
  ["content"]=>
  string(32) "w3schools.com test and test edit"
  ["id"]=>
  int(67973297)
  ["user_id"]=>
  int(2274710)
  ["user_name"]=>
  string(4) "Sean"
  ["room_id"]=>
  int(100286)
  ["room_name"]=>
  string(21) "Jeeves' Playground..."
  ["message_id"]=>
  int(33418667)
  ["message_edits"]=>
  int(1)
}
[2016-10-11 21:52:04] Processing room event #67973297 for built in event handlers
[2016-10-11 21:52:04] Event #67973297 processed for built in event handlers
[2016-10-11 21:52:04] Event #67973297 is not a command, it's a Room11\Jeeves\Chat\Message\Message
[2016-10-11 21:52:04] Processing room event #67973297 for plugins
[2016-10-11 21:52:04] Starting action executor loop
[2016-10-11 21:52:04] Post attempt 1
[2016-10-11 21:52:05] Got response from server: {"id":null,"time":null}
[2016-10-11 21:52:05] Got a null message post response, waiting for 1000ms before trying again
[2016-10-11 21:52:05] Backing off chat action execution for 1000ms
[2016-10-11 21:52:06] Websocket message received on connection to chat.stackoverflow.com#100286
string(59) "{"r100286":{"t":67973299,"d":2},"r11":{"t":67973299,"d":2}}"
[2016-10-11 21:52:06] Cancelling timeout watcher #0000000022edebc000000000350ff7b9
[2016-10-11 21:52:06] Created timeout watcher #0000000022edeb7800000000350ff7b9
[2016-10-11 21:52:06] 0 events targeting chat.stackoverflow.com#100286 to process
[2016-10-11 21:52:06] Post attempt 2
[2016-10-11 21:52:06] Got response from server: You can perform this action again in 4 seconds
[2016-10-11 21:52:06] Backing off chat action execution for 5100ms
[2016-10-11 21:52:11] Post attempt 3
[2016-10-11 21:52:11] Got response from server: {"id":null,"time":null}
[2016-10-11 21:52:11] Got a null message post response, waiting for 3000ms before trying again
[2016-10-11 21:52:11] Backing off chat action execution for 3000ms
[2016-10-11 21:52:14] Post attempt 4
[2016-10-11 21:52:15] Got response from server: {"id":null,"time":null}
[2016-10-11 21:52:15] Got a null message post response, waiting for 4000ms before trying again
[2016-10-11 21:52:15] Backing off chat action execution for 4000ms
[2016-10-11 21:52:19] Post attempt 5
[2016-10-11 21:52:19] Got response from server: You can perform this action again in 2 seconds
[2016-10-11 21:52:19] Backing off chat action execution for 3100ms
[2016-10-11 21:52:22] Executing an action failed after 5 attempts and I know when to quit
[2016-10-11 21:52:22] Action executor loop terminating
```