### PR TITLE
!!changelog: Allow specifying branch & fix fail cases

### DIFF
--- a/src/Plugins/Changelog.php
+++ b/src/Plugins/Changelog.php
@@ -57,14 +57,12 @@ class Changelog extends BasePlugin
             throw new ReferenceNotFoundException("Failed to fetch repository for $path");
         }
 
-        $json = json_decode($response->getBody());
-        $sha  = $json->object->sha ?? false;
-
-        if (!$sha) {
-            throw new ReferenceNotFoundException("Failed to fetch reference SHA for $path");
+        $commit = json_decode($response->getBody(), true);
+        if (!isset($commit['object'])) {
+            return $this->chatClient->postMessage($command->getRoom(), "Failed to fetch reference SHA for $path");
         }
 
-        return $sha;
+        return $commit['object']['sha'];
     }
 
     /**

--- a/src/Plugins/Changelog.php
+++ b/src/Plugins/Changelog.php
@@ -5,9 +5,12 @@ use Amp\Artax\HttpClient;
 use Amp\Artax\Response as HttpResponse;
 use Room11\Jeeves\Chat\Client\ChatClient;
 use Room11\Jeeves\Chat\Message\Command;
+use Room11\Jeeves\Exception;
 use Room11\Jeeves\Storage\KeyValue as KeyValueStore;
 use Room11\Jeeves\System\PluginCommandEndpoint;
 use Room11\Jeeves\Chat\Client\PostFlags;
+
+class ReferenceNotFoundException extends Exception {}
 
 class Changelog extends BasePlugin
 {
@@ -33,35 +36,40 @@ class Changelog extends BasePlugin
             return yield from $this->getLastCommit($command, $repository);
         }
 
-        return $this->chatClient->postMessage($command->getRoom(), "Usage: !!changelog [ <profile>/<repo> ]");
+        return $this->chatClient->postMessage($command->getRoom(), "Usage: !!changelog [ <profile>/<repo> <branch>]");
     }
 
     protected function getCommitReference(Command $command, string $path)
     {
         list($user, $repo) = explode('/', $path, 2);
 
+        $branch = $command->getParameter(1) ?? 'master';
+
         /** @var HttpResponse $response */
         $response = yield $this->httpClient->request(
             self::BASE_URL . '/repos/'
             . urlencode($user) . '/'
-            . urlencode($repo) . '/git/refs/heads/master'
+            . urlencode($repo) . '/git/refs/heads/'
+            . urlencode($branch)
         );
 
         if ($response->getStatus() !== 200) {
-            return $this->chatClient->postMessage($command->getRoom(), "Failed to fetch repo for $path");
+            throw new ReferenceNotFoundException("Failed to fetch repository for $path");
         }
 
         $json = json_decode($response->getBody());
-        if (!isset($json->object->sha)) {
-            return $this->chatClient->postMessage($command->getRoom(), "Failed to fetch reference SHA for $path");
+        $sha  = $json->object->sha ?? false;
+
+        if (!$sha) {
+            throw new ReferenceNotFoundException("Failed to fetch reference SHA for $path");
         }
 
-        return $json->object->sha;
+        return $sha;
     }
 
     /**
      * Example:
-     *   !!changelog Room-11/Jeeves
+     *   !!changelog Room-11/Jeeves <branch>
      *
      * @param Command $command
      * @param string $path
@@ -71,7 +79,11 @@ class Changelog extends BasePlugin
     {
         list($user, $repo) = explode('/', $path, 2);
 
-        $sha = yield from $this->getCommitReference($command, $path);
+        try {
+            $sha = yield from $this->getCommitReference($command, $path);
+        } catch (ReferenceNotFoundException $e) {
+            return $this->chatClient->postMessage($command->getRoom(), $e->getMessage());
+        }
 
         /** @var HttpResponse $response */
         $response = yield $this->httpClient->request(


### PR DESCRIPTION
Allows specifying a branch to get the latest commit from and fixes catchable fatal error if it cannot retrieve sha. Below is now valid.
`!!changelog ekinhbayar/Jeeves fix/changelog`


Closes #89 