### PR TITLE
Attempt to fix the [ -MASTER] thingy

### DIFF
--- a/src/Plugins/PHPSrcGrok.php
+++ b/src/Plugins/PHPSrcGrok.php
@@ -176,7 +176,7 @@ class PHPSrcGrok extends BasePlugin
 
     private function formatResultMessage(array $result)
     {
-        return sprintf('[ [%s](%s) ] `%s`', $result['path'], $result['href'], trim($result['code']));
+        return sprintf('[ [%s](%s) ] `%s`', substr($result['path'], 1), $result['href'], trim($result['code']));
     }
 
     public function getDefinition(Command $command): \Generator


### PR DESCRIPTION
Just remove the first character of `$result['path']` which is an annoying hyphen (`-`).